### PR TITLE
remove no badges comment

### DIFF
--- a/coderwall.py
+++ b/coderwall.py
@@ -115,8 +115,7 @@ def parse_json_data(json_data):
     name = data['name']
     location = data['location']
     endorsements = data['endorsements'] 
-    badges = data['badges'] # NOTE Not sure what is returned if user
-                            # has no badges
+    badges = data['badges']
 
     return (name, location, endorsements, badges)
 


### PR DESCRIPTION
not sure if you want to remove this comment.  here's an example response for someone who has no badges:

{
    "accounts": {
        "github": "someusername"
    }, 
    "badges": [], 
    "endorsements": 0, 
    "location": "San Francisco, CA", 
    "name": "Some Username", 
    "username": "someusername"
}
