### PR TITLE
Include readme file in package via manifest file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include *.txt
+include *.rst


### PR DESCRIPTION
Currently, installing this module via setup.py install fails due to a missing "readme.txt" file it's looking for. I took a look at the repo, and this should solve the problem. Let me know how it goes!
